### PR TITLE
Fix: Remove github actions task

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -57,6 +57,9 @@ jobs:
     - name: Run Quality Tools
       run: .ci/scripts/run.bash
 
+    - name: Check Reports
+      run: ls quality/detekt/reports
+
     env:
       DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -57,9 +57,6 @@ jobs:
     - name: Run Quality Tools
       run: .ci/scripts/run.bash
 
-    - name: Check Reports
-      run: ls quality/detekt/reports
-
     env:
       DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-minimal


### PR DESCRIPTION
Remove the Check Report task, this task stops Workflow when there is no report file.